### PR TITLE
Integrated fluxpoint.dev API and key handling

### DIFF
--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,0 +1,4 @@
+{
+  "python.interpreter" : "\/usr\/local\/bin\/python3",
+  "workspace.name" : "Nya"
+}

--- a/Nya/Configuration/ConfigManager.cs
+++ b/Nya/Configuration/ConfigManager.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Microsoft.Extensions.Configuration;
+
+namespace Nya.Configuration
+{
+	public static class ConfigManager
+	{
+		private static IConfigurationRoot configuration;
+
+		static ConfigManager()
+		{
+			configuration = new ConfigurationBuilder()
+				.SetBasePath(Directory.GetCurrentDirectory())
+				.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+				.Build();
+		}
+
+		public static string GetFluxpointApiKey()
+		{
+			return configuration["FluxpointApiKey"];
+		}
+	}
+}

--- a/Nya/Configuration/EndpointData.cs
+++ b/Nya/Configuration/EndpointData.cs
@@ -1,8 +1,128 @@
-﻿namespace Nya.Configuration
+﻿using System.Collections.Generic;
+
+namespace Nya.Configuration
 {
     internal class EndpointData
     {
         internal string? SelectedSfwEndpoint { get; set; }
         internal string? SelectedNsfwEndpoint { get; set; }
+
+        // Dictionary to store Fluxpoint SFW endpoints
+        public static readonly Dictionary<string, string> FluxpointSfwEndpoints = new Dictionary<string, string>
+        {
+            {"anime", "sfw/img/anime"},
+            {"azurlane", "sfw/img/azurlane"},
+            {"chibi", "sfw/img/chibi"},
+            {"christmas", "sfw/img/christmas"},
+            {"halloween", "sfw/img/halloween"},
+            {"holo", "sfw/img/holo"},
+            {"kitsune", "sfw/img/kitsune"},
+            {"maid", "sfw/img/maid"},
+            {"neko", "sfw/img/neko"},
+            {"nekoboy", "sfw/img/nekoboy"},
+            {"nekopara", "sfw/img/nekopara"},
+            {"senko", "sfw/img/senko"},
+            {"wallpaper", "sfw/img/wallpaper"},
+            
+        // SFW gif endpoints
+            {"baka", "sfw/gif/baka"},
+            {"bite", "sfw/gif/bite"},
+            {"blush", "sfw/gif/blush"},
+            {"cry", "sfw/gif/cry"},
+            {"dance", "sfw/gif/dance"},
+            {"feed", "sfw/gif/feed"},
+            {"fluff", "sfw/gif/fluff"},
+            {"grab", "sfw/gif/grab"},
+            {"handhold", "sfw/gif/handhold"},
+            {"highfive", "sfw/gif/highfive"},
+            {"hug", "sfw/gif/hug"},
+            {"kiss", "sfw/gif/kiss"},
+            {"lick", "sfw/gif/lick"},
+            {"neko gif", "sfw/gif/neko"},
+            {"pat", "sfw/gif/pat"},
+            {"poke", "sfw/gif/poke"},
+            {"punch", "sfw/gif/punch"},
+            {"shrug", "sfw/gif/shrug"},
+            {"slap", "sfw/gif/slap"},
+            {"smug", "sfw/gif/smug"},
+            {"stare", "sfw/gif/stare"},
+            {"tickle", "sfw/gif/tickle"},
+            {"wag", "sfw/gif/wag"},
+            {"wasted", "sfw/gif/wasted"},
+            {"wave", "sfw/gif/wave"},
+            {"wink", "sfw/gif/wink"},
+        };
+
+        // Dictionary to store Fluxpoint NSFW endpoints
+        public static readonly Dictionary<string, string> FluxpointNsfwEndpoints = new Dictionary<string, string>
+        {
+            {"anal", "nsfw/img/anal"},
+            {"anus", "nsfw/img/anus"},
+            {"ass", "nsfw/img/ass"},
+            {"azurlane", "nsfw/img/azurlane"},
+            {"bdsm", "nsfw/img/bdsm"},
+            {"blowjob", "nsfw/img/blowjob"},
+            {"boobs", "nsfw/img/boobs"},
+            {"cosplay", "nsfw/img/cosplay"},
+            {"cum", "nsfw/img/cum"},
+            {"feet", "nsfw/img/feet"},
+            {"futa", "nsfw/img/futa"},
+            {"gasm", "nsfw/img/gasm"},
+            {"holo", "nsfw/img/holo"},
+            {"lewd", "nsfw/img/lewd"},
+            {"neko", "nsfw/img/neko"},
+            {"nekopara", "nsfw/img/nekopara"},
+            {"pantyhose", "nsfw/img/pantyhose"},
+            {"peeing", "nsfw/img/peeing"},
+            {"petplay", "nsfw/img/petplay"},
+            {"pussy", "nsfw/img/pussy"},
+            {"slimes", "nsfw/img/slimes"},
+            {"solo", "nsfw/img/solo"},
+            {"trap", "nsfw/img/trap"},
+            {"yaoi", "nsfw/img/yaoi"},
+            {"yuri", "nsfw/img/yuri"},
+        
+        // NSFW gif endpoints
+            {"anal gif", "nsfw/gif/anal"},
+            {"ass gif", "nsfw/gif/ass"},
+            {"bdsm gif", "nsfw/gif/bdsm"},
+            {"blowjob gif", "nsfw/gif/blowjob"},
+            {"boobjob", "nsfw/gif/boobjob"},
+            {"boobs gif", "nsfw/gif/boobs"},
+            {"cum gif", "nsfw/gif/cum"},
+            {"feet gif", "nsfw/gif/feet"},
+            {"futa gif", "nsfw/gif/futa"},
+            {"handjob", "nsfw/gif/handjob"},
+            {"hentai", "nsfw/gif/hentai"},
+            {"kuni", "nsfw/gif/kuni"},
+            {"neko gif", "nsfw/gif/neko"},
+            {"pussy gif", "nsfw/gif/pussy"},
+            {"wank", "nsfw/gif/wank"},
+            {"solo gif", "nsfw/gif/solo"},
+            {"spank", "nsfw/gif/spank"},
+            {"tentacle gif", "nsfw/gif/tentacle"},
+            {"toys", "nsfw/gif/toys"},
+            {"yuri gif", "nsfw/gif/yuri"},
+        };
+
+        // Method to retrieve the endpoint based on category for SFW
+        public static string GetFluxpointSfwEndpoint(string category)
+        {
+            if (FluxpointSfwEndpoints.ContainsKey(category))
+            {
+                return FluxpointSfwEndpoints[category];
+            }
+            return null;
+        }
+
+        // Method to retrieve the endpoint based on category for NSFW
+        public static string GetFluxpointNsfwEndpoint(string category)
+        {
+            if (FluxpointNsfwEndpoints.ContainsKey(category))
+            {
+                return FluxpointNsfwEndpoints[category];
+            }
+            return null;
+        }
     }
 }

--- a/Nya/Configuration/appsettings.json
+++ b/Nya/Configuration/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "FluxpointApiKey": "your_api_key_here"
+}

--- a/Nya/Entries/WebAPIEntries.cs
+++ b/Nya/Entries/WebAPIEntries.cs
@@ -1,4 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nya.Configuration;
 
 namespace Nya.Entries
 {
@@ -6,5 +11,20 @@ namespace Nya.Entries
     {
         [JsonProperty("url")]
         public string? Url { get; set; }
+
+        // Method to get images from Fluxpoint with authentication
+        public static async Task<string> GetImageFromFluxpointAsync(string category)
+        {
+            string apiKey = ConfigManager.GetFluxpointApiKey();
+            string url = $"https://gallery.fluxpoint.dev/api/sfw/img/{category}";
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                HttpResponseMessage response = await client.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync();
+            }
+        }
     }
 }

--- a/Nya/Managers/ImageSourcesManager.cs
+++ b/Nya/Managers/ImageSourcesManager.cs
@@ -29,17 +29,17 @@ namespace Nya.Managers
             _pluginConfig = pluginConfig;
             _pluginMetadata = pluginMetadata.Value;
         }
-        
+
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
-        
+
         private Dictionary<string, ImageSourceEntry>? _sources;
-        private bool _sourceFetchSuccesful;
+        private bool _sourceFetchSuccessful;
 
         private async Task<Dictionary<string, ImageSourceEntry>> PopulateSources()
         {
             Dictionary<string, ImageSourceEntry> sources = new Dictionary<string, ImageSourceEntry>();
-            
-            _sourceFetchSuccesful = false;
+
+            _sourceFetchSuccessful = false;
             try
             {
                 if (new Uri(Plugin.ImageSourcesJsonLink).IsFile)
@@ -60,8 +60,15 @@ namespace Nya.Managers
                     {
                         var jsonString = await response.ReadAsStringAsync();
                         sources = JsonConvert.DeserializeObject<Dictionary<string, ImageSourceEntry>>(jsonString);
-                    }   
+                    }
                 }
+
+                // Existing sources added here, keep them as they are.
+
+                // Add fluxpoint.dev as a new source
+                AddFluxpointDevSource(sources);
+
+                _sourceFetchSuccessful = true;
             }
 
                 // Add fluxpoint.dev as a new source
@@ -79,9 +86,7 @@ namespace Nya.Managers
                 _siraLog.Error("Failed to fetch image sources from " + Plugin.ImageSourcesJsonLink);
                 _siraLog.Error(e);
             }
-            
-            _sourceFetchSuccesful = true;
-            
+
             sources["Local Files"] = new ImageSourceEntry
             {
                 Url = Path.Combine(UnityGame.UserDataPath, "Nya"),
@@ -89,14 +94,35 @@ namespace Nya.Managers
                 SfwEndpoints = PopulateLocalEndpoints(false),
                 NsfwEndpoints = PopulateLocalEndpoints(true)
             };
-            
+
             return sources;
         }
-        
+
+        private void AddFluxpointDevSource(Dictionary<string, ImageSourceEntry> sources)
+        {
+            string apiKey = ConfigManager.GetFluxpointApiKey();
+            if (string.IsNullOrEmpty(apiKey))
+            {
+                _siraLog.Error("API key for fluxpoint.dev is missing.");
+                return;
+            }
+
+            // Use EndpointData to get SFW and NSFW endpoints
+            var sfwEndpoints = EndpointData.FluxpointSfwEndpoints.Values.ToList();
+            var nsfwEndpoints = EndpointData.FluxpointNsfwEndpoints.Values.ToList();
+
+            sources["fluxpoint.dev"] = new ImageSourceEntry
+            {
+                DisplayName = "Fluxpoint",
+                SfwEndpoints = sfwEndpoints.Select(endpoint => $"https://gallery.fluxpoint.dev/api/{endpoint}").ToList(),
+                NsfwEndpoints = nsfwEndpoints.Select(endpoint => $"https://gallery.fluxpoint.dev/api/{endpoint}").ToList()
+            };
+        }
+
         private static List<string> PopulateLocalEndpoints(bool nsfw)
         {
             var baseFolder = nsfw ? "nsfw" : "sfw";
-            var endpoints = new List<string> {baseFolder};
+            var endpoints = new List<string> { baseFolder };
 
             foreach (var folder in Directory.GetDirectories(Path.Combine(UnityGame.UserDataPath, "Nya", baseFolder)))
             {
@@ -108,17 +134,16 @@ namespace Nya.Managers
 
         private void FixConfigImageSourcesIssues(Dictionary<string, ImageSourceEntry> sources)
         {
-            if (!_sourceFetchSuccesful)
+            if (!_sourceFetchSuccessful)
             {
                 // Don't want to nuke the config just because the user booted the game without internet or something
                 return;
             }
-            
+
             // Stops any changes to the config happening until this method is done
             using var _ = _pluginConfig.ChangeTransaction;
-            
+
             // Check that the config doesn't have any invalid sources saved
-            // Can't use a foreach loop here because we're modifying the dictionary, doing so would throw an InvalidOperationException.
             for (int i = _pluginConfig.SelectedEndpoints.Count - 1; i >= 0; i--)
             {
                 var source = _pluginConfig.SelectedEndpoints.ElementAt(i);
@@ -127,13 +152,13 @@ namespace Nya.Managers
                     _pluginConfig.SelectedEndpoints.Remove(source.Key);
                 }
             }
-            
+
             // Checks that the selected source is valid
             if (!sources.ContainsKey(_pluginConfig.SelectedAPI))
             {
                 _pluginConfig.SelectedAPI = sources.First().Key;
             }
-            
+
             foreach (var source in sources)
             {
                 // Adds a new source to the selected endpoints dictionary
@@ -145,14 +170,14 @@ namespace Nya.Managers
                         SelectedNsfwEndpoint = source.Value.NsfwEndpoints.FirstOrDefault()
                     };
                 }
-                
+
                 // Checks the sfw endpoint of the source exists
                 var sfwEndpoint = _pluginConfig.SelectedEndpoints[source.Key].SelectedSfwEndpoint;
                 if (sfwEndpoint == null || !source.Value.SfwEndpoints.Contains(sfwEndpoint))
                 {
                     _pluginConfig.SelectedEndpoints[source.Key].SelectedSfwEndpoint = source.Value.SfwEndpoints.FirstOrDefault();
                 }
-                
+
                 // Checks the nsfw endpoint of the source exists
                 var nsfwEndpoint = _pluginConfig.SelectedEndpoints[source.Key].SelectedNsfwEndpoint;
                 if (nsfwEndpoint == null || !source.Value.NsfwEndpoints.Contains(nsfwEndpoint))
@@ -160,10 +185,10 @@ namespace Nya.Managers
                     _pluginConfig.SelectedEndpoints[source.Key].SelectedNsfwEndpoint = source.Value.NsfwEndpoints.FirstOrDefault();
                 }
             }
-            
+
             _pluginConfig.Changed();
         }
-        
+
         public async Task<Dictionary<string, ImageSourceEntry>> GetSourcesDictionary()
         {
             await _semaphore.WaitAsync();

--- a/Nya/Managers/ImageSourcesManager.cs
+++ b/Nya/Managers/ImageSourcesManager.cs
@@ -63,6 +63,17 @@ namespace Nya.Managers
                     }   
                 }
             }
+
+                // Add fluxpoint.dev as a new source
+                sources["fluxpoint.dev"] = new ImageSourceEntry
+                {
+                    DisplayName = "Fluxpoint",
+                    SfwEndpoints = new List<string> { "https://gallery.fluxpoint.dev/api/sfw/img/anime" },
+                    NsfwEndpoints = new List<string> { "https://gallery.fluxpoint.dev/api/nsfw/img" } // Example NSFW endpoint
+                };
+
+                _sourceFetchSuccesful = true;
+        }
             catch (Exception e)
             {
                 _siraLog.Error("Failed to fetch image sources from " + Plugin.ImageSourcesJsonLink);


### PR DESCRIPTION
- Added `ConfigManager.cs` for API key retrieval from configuration.
- Updated `WebAPIEntries.cs` to include authenticated requests for images from `fluxpoint.dev`.
- Modified `ImageSourcesManager.cs` to add `fluxpoint.dev` as an image source.
- Refactored `EndpointData.cs` to include new categories for SFW and NSFW images and GIFs.
- Updated `PluginConfig.cs` to ensure consistency with new configuration approach.
- Set up storage and retrieval of the `fluxpoint.dev` API key.

Right now the gif endpoints don't work because of the site path /img vs /gif. Really just want to add animated gif only support which I saw was done in the quest build for Nya.